### PR TITLE
Allow use of structs in other projects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default = ["std"]
 [dependencies]
 nom = { version = "7", default-features = false }
 heapless = { version = "0.7" }
+serde = { version = "1.0.152", features = ["derive"] }
 
 [[bin]]
 name = "aisparser"

--- a/src/messages/binary_broadcast_message.rs
+++ b/src/messages/binary_broadcast_message.rs
@@ -70,8 +70,8 @@ impl AssignedMode {
     }
 }
 
-fn parse_base(data: &[u8]) -> IResult<&[u8], BinaryBroadcastMessage> {
-    bits(move |data: (&[u8], usize)| -> IResult<_, _> {
+fn parse_base<'a> (data: &'a [u8]) -> IResult<&'a [u8], BinaryBroadcastMessage> {
+    bits (move |data: (&'a [u8], usize)| -> IResult<_, _> {
         let (data, message_type) = take_bits(6u8)(data)?;
         let (data, repeat_indicator) = take_bits(2u8)(data)?;
         let (data, mmsi) = take_bits(30u32)(data)?;

--- a/src/messages/data_link_management_message.rs
+++ b/src/messages/data_link_management_message.rs
@@ -59,8 +59,8 @@ impl<'a> AisMessageType<'a> for DataLinkManagementMessage {
     }
 }
 
-fn parse_base(data: &[u8]) -> IResult<&[u8], DataLinkManagementMessage> {
-    bits(move |data: (&[u8], usize)| -> IResult<_, _> {
+fn parse_base<'a> (data: &'a [u8]) -> IResult<&'a [u8], DataLinkManagementMessage> {
+    bits(move |data: (&'a [u8], usize)| -> IResult<_, _> {
         let (data, message_type) = take_bits(6u8)(data)?;
         let (data, repeat_indicator) = take_bits(2u8)(data)?;
         let (data, mmsi) = take_bits(30u32)(data)?;

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -19,7 +19,7 @@ mod radio_status;
 pub mod standard_class_b_position_report;
 pub mod static_and_voyage_related_data;
 pub mod static_data_report;
-mod types;
+pub mod types;
 pub mod utc_date_response;
 
 pub use parsers::message_type;

--- a/src/messages/types.rs
+++ b/src/messages/types.rs
@@ -1,8 +1,11 @@
 //! Common data types
 
+use serde::{Deserialize, Serialize};
+
 /// Electronic Position Fixing Device type. This is the
 /// type of device used for determining the object's
 /// position.
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum EpfdType {
     Gps,
@@ -34,7 +37,8 @@ impl EpfdType {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum ShipType {
     Reserved,
     WingInGround,
@@ -168,6 +172,7 @@ impl ShipType {
     }
 }
 
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq)]
 pub enum Dte {
     Ready,
@@ -190,6 +195,7 @@ impl From<u8> for Dte {
     }
 }
 
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq)]
 pub enum AssignedMode {
     Autonomous,


### PR DESCRIPTION
For my own project I need to receive and parse AIS messages.

As I want to store AIS static data so that when the program restarts it has a ready database of vessel names etc, I need to serialise this data. Due to how Rust works I needed the `types` struct to be `pub`.

In due course I also found a lifetime issue in two files that no longer compile under Rust 1.67 with updated crates.