### PR TITLE
feat: add support for tag block, integrate UDP, TCP, file and single message parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,11 @@ default = ["std"]
 
 [dependencies]
 nom = { version = "7", default-features = false }
-heapless = { version = "0.7" }
+heapless = { version = "0.8.0" }
+tokio = { version = "1.0", features = ["full"] }
+clap = "4.5.11"
+tempfile = "3"
+
 
 [[bin]]
 name = "aisparser"

--- a/src/bin/aisparser.rs
+++ b/src/bin/aisparser.rs
@@ -1,35 +1,56 @@
-use ais::lib;
+use ais::{decode, decode_from_file, decode_from_tcp, decode_from_udp};
+use clap::{Arg, Command};
+use std::error::Error;
 
-use ais::sentence::{AisFragments, AisParser};
-use lib::std::io::BufRead;
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let matches = Command::new("ais-decode")
+        .version("1.0")
+        .about("AIS message decoding")
+        .arg(
+            Arg::new("udp")
+                .short('u')
+                .long("udp")
+                .value_name("ADDRESS")
+                .help("Address to listen for UDP messages"),
+        )
+        .arg(
+            Arg::new("tcp")
+                .short('t')
+                .long("tcp")
+                .value_name("ADDRESS")
+                .help("Address to connect for TCP messages"),
+        )
+        .arg(
+            Arg::new("file")
+                .short('f')
+                .long("file")
+                .value_name("PATH")
+                .help("Path to the file to read AIS messages from"),
+        )
+        .arg(
+            Arg::new("message")
+                .short('m')
+                .long("message")
+                .value_name("AIS_MESSAGE")
+                .help("A single AIS message to decode"),
+        )
+        .get_matches();
 
-use lib::std::io;
-
-fn parse_nmea_line(parser: &mut AisParser, line: &[u8]) -> Result<(), ais::errors::Error> {
-    let sentence = parser.parse(line, true)?;
-    if let AisFragments::Complete(sentence) = sentence {
-        println!(
-            "{:?}\t{:?}",
-            lib::std::str::from_utf8(line).unwrap(),
-            sentence.message
-        );
+    if let Some(address) = matches.get_one::<String>("udp") {
+        decode_from_udp(address).await?;
+    } else if let Some(address) = matches.get_one::<String>("tcp") {
+        decode_from_tcp(address).await?;
+    } else if let Some(path) = matches.get_one::<String>("file") {
+        decode_from_file(path).await?;
+    } else if let Some(message) = matches.get_one::<String>("message") {
+        match decode(message.as_bytes()) {
+            Ok(parsed_message) => println!("Parsed AIS Message: {:?}", parsed_message),
+            Err(e) => eprintln!("Failed to parse AIS message: {}", e),
+        }
+    } else {
+        eprintln!("No valid command provided.");
     }
+
     Ok(())
-}
-
-fn main() {
-    let mut parser = AisParser::new();
-    let stdin = io::stdin();
-    {
-        let handle = stdin.lock();
-
-        handle
-            .split(b'\n')
-            .map(|line| line.unwrap())
-            .for_each(|line| {
-                parse_nmea_line(&mut parser, &line).unwrap_or_else(|err| {
-                    eprintln!("{:?}\t{:?}", lib::std::str::from_utf8(&line).unwrap(), err);
-                });
-            });
-    }
 }

--- a/src/decoders/mod.rs
+++ b/src/decoders/mod.rs
@@ -1,0 +1,2 @@
+//! Function utilities
+pub mod utils;

--- a/src/decoders/utils.rs
+++ b/src/decoders/utils.rs
@@ -1,0 +1,296 @@
+use crate::errors::Error;
+use crate::messages::tag_block::TagBlock;
+use crate::messages::AisMessage;
+use crate::sentence::{AisFragments, AisParser};
+use std::error::Error as StdError;
+use tokio::fs::File;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::net::{TcpStream, UdpSocket};
+/// Parses a single line of NMEA data using the provided AIS parser.
+///
+/// This function attempts to parse a given NMEA line into a tag block and an AIS message,
+/// printing the results to the console.
+///
+/// # Arguments
+/// * `parser` - The AIS parser to use.
+/// * `line` - A byte slice containing the NMEA line to parse.
+///
+
+async fn parse_nmea_line(parser: &mut AisParser, line: &[u8]) {
+    // Convert the line to a string
+    let line_str = std::str::from_utf8(line).expect("Invalid UTF-8 sequence");
+
+    // Print the received message
+    println!("Received message: {}", line_str);
+
+    // Check for a tag block by looking for the start of a NMEA sentence ('!')
+    if let Some(nmea_start_idx) = line_str.find('!') {
+        // Extract the tag block (everything before the '!') and the NMEA sentence
+        let tag_block_str = &line_str[..nmea_start_idx];
+        let nmea_sentence = &line_str[nmea_start_idx..];
+
+        // Check if there's a valid tag block (should start and end with '\')
+        if tag_block_str.starts_with('\\') && tag_block_str.ends_with('\\') {
+            // Remove the leading and trailing backslashes from the tag block
+            let tag_block_content = &tag_block_str[1..tag_block_str.len() - 1];
+
+            // Parse the tag block
+            match TagBlock::parse(tag_block_content) {
+                Ok(Some(tag_block)) => {
+                    println!("Parsed TagBlock: {:?}", tag_block);
+                }
+                Ok(None) => {
+                    println!("No tag block found");
+                }
+                Err(err) => {
+                    eprintln!("Error parsing tag block: {}", err);
+                    return;
+                }
+            }
+        }
+
+        // Parse the NMEA sentence
+        match parser.parse(nmea_sentence.as_bytes(), true) {
+            Ok((_, AisFragments::Complete(sentence))) => {
+                println!(
+                    "Parsed NMEA Sentence: {:?}\nMessage: {:?}",
+                    nmea_sentence, sentence.message
+                );
+            }
+            Err(err) => {
+                eprintln!("Error parsing line {:?}: {:?}", nmea_sentence, err);
+            }
+            _ => {}
+        }
+
+        // Print separator between messages
+        println!("*************************");
+    } else {
+        eprintln!("No valid NMEA sentence found in line");
+    }
+}
+
+/// Decodes a stream of AIS messages from UDP.
+///
+/// This function binds to the given UDP address and decodes incoming AIS messages, printing the results to the console.
+///
+/// # Arguments
+/// * `address` - The address to bind to in the form "ip:port".
+///
+
+pub async fn decode_from_udp(address: &str) -> Result<(), Box<dyn StdError>> {
+    let socket = UdpSocket::bind(address).await?;
+    let mut buf = [0; 1024];
+    let mut parser = AisParser::new();
+
+    loop {
+        let (len, _) = socket.recv_from(&mut buf).await?;
+        parse_nmea_line(&mut parser, &buf[..len]).await;
+    }
+}
+
+/// Decodes a stream of AIS messages from TCP.
+///
+/// This function connects to the given TCP address and decodes incoming AIS messages,
+/// printing the results to the console.
+///
+/// # Arguments
+/// * `address` - The address to connect to in the form "ip:port".
+///
+pub async fn decode_from_tcp(address: &str) -> Result<(), Box<dyn StdError>> {
+    let stream = TcpStream::connect(address).await?;
+    let mut parser = AisParser::new();
+    let mut reader = BufReader::new(stream);
+    let mut line = Vec::new();
+
+    while reader.read_until(b'\n', &mut line).await? != 0 {
+        parse_nmea_line(&mut parser, &line).await;
+        line.clear();
+    }
+
+    Ok(())
+}
+
+/// Decodes a file of AIS messages.
+///
+/// This function reads AIS messages from a file and decodes them, printing the results to the console.
+///
+/// # Arguments
+/// * `path` - The path to the file containing AIS messages.
+///
+///
+pub async fn decode_from_file(path: &str) -> Result<(), Box<dyn StdError>> {
+    let file = File::open(path).await?;
+    let reader = BufReader::new(file);
+    let mut lines = reader.lines();
+    let mut parser = AisParser::new();
+
+    while let Some(line) = lines.next_line().await? {
+        parse_nmea_line(&mut parser, line.as_bytes()).await;
+    }
+
+    Ok(())
+}
+
+/// Decodes a single AIS message.
+///
+/// This function parses a single AIS message from a byte slice and returns the parsed message.
+///
+/// # Arguments
+/// * `message` - A byte slice containing the AIS message to parse.
+///
+/// # Returns
+/// * A result containing the parsed AIS message or an error.
+///
+/// # Errors
+/// * Returns an error if the message is incomplete or cannot be parsed.
+///
+
+pub fn decode(message: &[u8]) -> Result<AisMessage, Error> {
+    let mut parser = AisParser::new();
+    match parser.parse(message, true)? {
+        (Some(tag_block), AisFragments::Complete(sentence)) => {
+            println!("TagBlock: {:?}", tag_block);
+            sentence.message.ok_or(Error::Nmea {
+                msg: "Incomplete message".into(),
+            })
+        }
+        (None, AisFragments::Complete(sentence)) => sentence.message.ok_or(Error::Nmea {
+            msg: "Incomplete message".into(),
+        }),
+        _ => Err(Error::Nmea {
+            msg: "Incomplete message".into(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::messages::position_report::NavigationStatus;
+    use tempfile;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::{TcpListener, UdpSocket};
+
+    // Function to validate PositionReport messages
+    fn validate_position_report(report: &crate::messages::position_report::PositionReport) {
+        assert_eq!(report.message_type, 1);
+        assert_eq!(report.mmsi, 367380120);
+        assert_eq!(
+            report.navigation_status,
+            Some(NavigationStatus::UnderWayUsingEngine)
+        );
+        assert_eq!(report.speed_over_ground, Some(0.1));
+        assert_eq!(report.longitude, Some(-122.404335));
+        assert_eq!(report.latitude, Some(37.806946));
+        assert_eq!(report.course_over_ground, Some(245.2));
+        assert_eq!(report.timestamp, 59);
+        assert!(report.raim);
+    }
+
+    #[tokio::test]
+    async fn test_parse_nmea_line() {
+        let mut parser = AisParser::new();
+        let line = b"!AIVDM,1,1,,B,15NG6V0P01G?cFhE`R2IU?wn28R>,0*05";
+
+        parse_nmea_line(&mut parser, line).await;
+
+        if let Ok((_, AisFragments::Complete(sentence))) = parser.parse(line, true) {
+            if let Some(AisMessage::PositionReport(ref report)) = sentence.message {
+                validate_position_report(report);
+            } else {
+                panic!("Failed to parse message as PositionReport");
+            }
+        } else {
+            panic!("Failed to parse NMEA line");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_decode_from_udp() {
+        let address = "127.0.0.1:12345";
+        let test_data = b"!AIVDM,1,1,,B,15NG6V0P01G?cFhE`R2IU?wn28R>,0*05";
+
+        let server_handle = tokio::spawn(async move {
+            decode_from_udp(address).await.unwrap();
+        });
+
+        let client = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        client.send_to(test_data, address).await.unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let mut parser = AisParser::new();
+        if let Ok((_, AisFragments::Complete(sentence))) = parser.parse(test_data, true) {
+            if let Some(AisMessage::PositionReport(ref report)) = sentence.message {
+                validate_position_report(report);
+            } else {
+                panic!("Failed to parse message as PositionReport");
+            }
+        } else {
+            panic!("Failed to parse NMEA line");
+        }
+
+        server_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_decode_from_tcp() {
+        let address = "127.0.0.1:12346";
+        let listener = TcpListener::bind(address).await.unwrap();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let test_data = b"!AIVDM,1,1,,B,15NG6V0P01G?cFhE`R2IU?wn28R>,0*05\n";
+            socket.write_all(test_data).await.unwrap();
+        });
+
+        decode_from_tcp(address).await.unwrap();
+
+        let message = b"!AIVDM,1,1,,B,15NG6V0P01G?cFhE`R2IU?wn28R>,0*05";
+        let mut parser = AisParser::new();
+        if let Ok((_, AisFragments::Complete(sentence))) = parser.parse(message, true) {
+            if let Some(AisMessage::PositionReport(ref report)) = sentence.message {
+                validate_position_report(report);
+            } else {
+                panic!("Failed to parse message as PositionReport");
+            }
+        } else {
+            panic!("Failed to parse NMEA line");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_decode_from_file() {
+        let test_data = b"!AIVDM,1,1,,B,15NG6V0P01G?cFhE`R2IU?wn28R>,0*05\n";
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("test_file.txt");
+        tokio::fs::write(&file_path, test_data).await.unwrap();
+
+        decode_from_file(file_path.to_str().unwrap()).await.unwrap();
+
+        let mut parser = AisParser::new();
+        if let Ok((_, AisFragments::Complete(sentence))) = parser.parse(test_data, true) {
+            if let Some(AisMessage::PositionReport(ref report)) = sentence.message {
+                validate_position_report(report);
+            } else {
+                panic!("Failed to parse message as PositionReport");
+            }
+        } else {
+            panic!("Failed to parse NMEA line");
+        }
+    }
+
+    #[test]
+    fn test_decode() {
+        let message = b"!AIVDM,1,1,,B,15NG6V0P01G?cFhE`R2IU?wn28R>,0*05";
+        let result = decode(message);
+
+        match result {
+            Ok(AisMessage::PositionReport(ref report)) => {
+                validate_position_report(report);
+            }
+            _ => panic!("Failed to decode the message correctly"),
+        }
+    }
+}

--- a/src/decoders/utils.rs
+++ b/src/decoders/utils.rs
@@ -2,7 +2,7 @@ use crate::errors::Error;
 use crate::messages::tag_block::TagBlock;
 use crate::messages::AisMessage;
 use crate::sentence::{AisFragments, AisParser};
-use std::error::Error as StdError;
+use crate::lib::std::error::Error as StdError;
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::net::{TcpStream, UdpSocket};

--- a/src/messages/binary_broadcast_message.rs
+++ b/src/messages/binary_broadcast_message.rs
@@ -70,8 +70,8 @@ impl AssignedMode {
     }
 }
 
-fn parse_base<'a> (data: &'a [u8]) -> IResult<&'a [u8], BinaryBroadcastMessage> {
-    bits (move |data: (&'a [u8], usize)| -> IResult<_, _> {
+fn parse_base<'a>(data: &'a [u8]) -> IResult<&'a [u8], BinaryBroadcastMessage> {
+    bits(move |data: (&'a [u8], usize)| -> IResult<_, _> {
         let (data, message_type) = take_bits(6u8)(data)?;
         let (data, repeat_indicator) = take_bits(2u8)(data)?;
         let (data, mmsi) = take_bits(30u32)(data)?;

--- a/src/messages/data_link_management_message.rs
+++ b/src/messages/data_link_management_message.rs
@@ -59,7 +59,7 @@ impl<'a> AisMessageType<'a> for DataLinkManagementMessage {
     }
 }
 
-fn parse_base<'a> (data: &'a [u8]) -> IResult<&'a [u8], DataLinkManagementMessage> {
+fn parse_base<'a>(data: &'a [u8]) -> IResult<&'a [u8], DataLinkManagementMessage> {
     bits(move |data: (&'a [u8], usize)| -> IResult<_, _> {
         let (data, message_type) = take_bits(6u8)(data)?;
         let (data, repeat_indicator) = take_bits(2u8)(data)?;

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -19,6 +19,7 @@ pub mod radio_status;
 pub mod standard_class_b_position_report;
 pub mod static_and_voyage_related_data;
 pub mod static_data_report;
+pub mod tag_block;
 pub mod types;
 pub mod utc_date_response;
 pub mod standard_aircraft_position_report;

--- a/src/messages/tag_block.rs
+++ b/src/messages/tag_block.rs
@@ -1,0 +1,231 @@
+use std::result::Result;
+
+/// Tag blocks are optional components of AIS messages that provide additional metadata
+/// through key-value pairs. These key-value pairs are enclosed within backslashes and
+/// followed by a checksum. The metadata can include timestamps, source and destination
+/// stations, line counts, relative times, and text. The checksum is used to validate the
+/// integrity of the tag block. For more details, refer to the official documentation:
+/// [NMEA Tag Blocks](https://gpsd.gitlab.io/gpsd/AIVDM.html#_nmea_tag_blocks).
+///
+/// Fields:
+/// - `receiver_timestamp`: UNIX time in seconds or milliseconds.
+/// - `destination_station`: Destination station, up to 15 characters.
+/// - `line_count`: Line count.
+/// - `relative_time`: Relative time.
+/// - `source_station`: Source station.
+/// - `text`: Text string, up to 15 characters.
+/// - `checksum`: Checksum for validation.
+#[derive(Debug, PartialEq)]
+pub struct TagBlock {
+    pub receiver_timestamp: Option<u64>,
+    pub destination_station: Option<String>,
+    pub line_count: Option<u32>,
+    pub relative_time: Option<u32>,
+    pub source_station: Option<String>,
+    pub text: Option<String>,
+    pub checksum: u8,
+}
+
+impl TagBlock {
+    /// Parses a tag block from a given input string.
+    ///
+    /// # Arguments
+    /// * `input` - A string slice that holds the tag block to be parsed.
+    ///
+    /// # Returns
+    /// * `Ok(Some(TagBlock))` if parsing is successful.
+    /// * `Ok(None)` if the tag block is empty.
+    /// * `Err(String)` if the tag block format is invalid or if there is a checksum mismatch.
+    pub fn parse(input: &str) -> Result<Option<Self>, String> {
+        // Remove leading and trailing backslashes
+        let input = input.trim_matches('\\');
+        let parts: Vec<&str> = input.split('*').collect();
+
+        if parts.len() != 2 {
+            return Err("Invalid tag block format: missing checksum".into());
+        }
+
+        let key_value_part = parts[0];
+        let checksum_str = parts[1];
+
+        // Ensure checksum string length is 2
+        if checksum_str.len() != 2 {
+            return Err("Invalid checksum format: checksum should be 2 characters".into());
+        }
+
+        // Parse the provided checksum
+        let provided_checksum = u8::from_str_radix(checksum_str, 16).map_err(|_| {
+            "Invalid checksum format: checksum is not a valid hexadecimal number".to_string()
+        })?;
+
+        // Calculate the checksum
+        let calculated_checksum = calculate_checksum(key_value_part.as_bytes());
+        if calculated_checksum != provided_checksum {
+            return Err(format!(
+                "Checksum mismatch: calculated {:#02X}, expected {:#02X}",
+                calculated_checksum, provided_checksum
+            ));
+        }
+
+        let mut tag_block = TagBlock {
+            receiver_timestamp: None,
+            destination_station: None,
+            line_count: None,
+            relative_time: None,
+            source_station: None,
+            text: None,
+            checksum: provided_checksum,
+        };
+
+        // Parse key-value pairs
+        for kv in key_value_part.split(',') {
+            if kv.len() < 3 {
+                continue;
+            }
+
+            let (key, value) = kv.split_at(2);
+            let value = value.to_string();
+
+            match key {
+                "c:" => {
+                    tag_block.receiver_timestamp = value.parse().ok();
+                }
+                "d:" => {
+                    tag_block.destination_station = Some(value);
+                }
+                "n:" => {
+                    tag_block.line_count = value.parse().ok();
+                }
+                "r:" => {
+                    tag_block.relative_time = value.parse().ok();
+                }
+                "s:" => {
+                    tag_block.source_station = Some(value);
+                }
+                "t:" => {
+                    tag_block.text = Some(value);
+                }
+                _ => {
+                    // Ignore unknown keys
+                }
+            }
+        }
+
+        Ok(Some(tag_block))
+    }
+}
+
+/// Calculates the checksum for the provided data using XOR operation.
+///
+/// # Arguments
+/// * `data` - A byte slice of data for which the checksum is to be calculated.
+///
+/// # Returns
+/// * `u8` - The calculated checksum.
+fn calculate_checksum(data: &[u8]) -> u8 {
+    data.iter().fold(0u8, |acc, &item| acc ^ item)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_tag_block(
+        input: &str,
+        expected_receiver_timestamp: Option<u64>,
+        expected_source_station: Option<String>,
+        expected_destination_station: Option<String>,
+        expected_line_count: Option<u32>,
+        expected_relative_time: Option<u32>,
+        expected_text: Option<String>,
+        expected_checksum: u8,
+    ) {
+        let tag_block = TagBlock::parse(input).unwrap().unwrap();
+
+        assert_eq!(tag_block.receiver_timestamp, expected_receiver_timestamp);
+        assert_eq!(tag_block.source_station, expected_source_station);
+        assert_eq!(tag_block.destination_station, expected_destination_station);
+        assert_eq!(tag_block.line_count, expected_line_count);
+        assert_eq!(tag_block.relative_time, expected_relative_time);
+        assert_eq!(tag_block.text, expected_text);
+        assert_eq!(tag_block.checksum, expected_checksum);
+    }
+
+    #[test]
+    fn parse_tag_block_with_valid_data() {
+        let input = r"\s:2573598,c:1720090996*00\";
+        assert_tag_block(
+            input,
+            Some(1720090996),
+            Some("2573598".to_string()),
+            None,
+            None,
+            None,
+            None,
+            0x00,
+        );
+    }
+
+    #[test]
+    fn parse_tag_block_with_all_fields() {
+        let input = r"\s:2573135,c:1671620143,d:FooBar,n:123,r:456,t:HelloWorld!*36\";
+        assert_tag_block(
+            input,
+            Some(1671620143),
+            Some("2573135".to_string()),
+            Some("FooBar".to_string()),
+            Some(123),
+            Some(456),
+            Some("HelloWorld!".to_string()),
+            0x36,
+        );
+    }
+
+    #[test]
+    fn parse_tag_block_with_invalid_format() {
+        let input = r"invalid_tag_block_format";
+        let result = TagBlock::parse(input);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            "Invalid tag block format: missing checksum"
+        );
+    }
+
+    #[test]
+    fn parse_tag_block_with_invalid_checksum_format() {
+        let input = r"\s:2573135,c:1671620143*GG\";
+        let result = TagBlock::parse(input);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            "Invalid checksum format: checksum is not a valid hexadecimal number"
+        );
+    }
+
+    #[test]
+    fn parse_tag_block_with_checksum_mismatch() {
+        let input = r"\s:2573135,c:1671620143*FF\";
+        let result = TagBlock::parse(input);
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Checksum mismatch"));
+    }
+
+    #[test]
+    fn parse_tag_block_with_unknown_keys() {
+        let input = r"\x:unknown_key,s:2573135,c:1671620143*25\";
+        assert_tag_block(
+            input,
+            Some(1671620143),
+            Some("2573135".to_string()),
+            None,
+            None,
+            None,
+            None,
+            0x25,
+        );
+    }
+}

--- a/src/sentence.rs
+++ b/src/sentence.rs
@@ -12,6 +12,7 @@ use nom::combinator::{map, map_res, opt, peek, verify};
 use nom::number::complete::hex_u32;
 use nom::sequence::{delimited, terminated};
 use nom::IResult;
+use crate::lib::std::format;
 
 pub const MAX_SENTENCE_SIZE_BYTES: usize = 384;
 


### PR DESCRIPTION
I documented each change i did so ( cargo doc ) would be so helpful especially in the Tag Block part. 

Previously, the library ignored these prefixes, but with the recent improvements, it now parses them effectively, preserving essential contextual metadata. The screenshot below demonstrates how the library is able to parse both types of messages with and without a tag block : 
![tag_block_parsing_test_tcp](https://github.com/user-attachments/assets/e122f186-b3b9-4d76-8d8b-381e31aec737)

![Screenshot from 2024-10-07 02-43-05](https://github.com/user-attachments/assets/9b06913b-199c-49b8-b307-76babe160196)


![Screenshot from 2024-10-07 02-43-20](https://github.com/user-attachments/assets/6142f5a9-2637-4c28-bddb-3a9d854a3dd2)



![Screenshot from 2024-08-21 15-36-34](https://github.com/user-attachments/assets/73349f57-d7f5-496e-87f4-088d304e4720)



![Screenshot from 2024-08-21 15-37-19](https://github.com/user-attachments/assets/70ae059d-8bca-4b4c-a96f-e58eab2a8661)







